### PR TITLE
Allow to configure syslog port / hostname / dest file and json format 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,28 @@
 # pm2-syslog
 
-Redirect all logs of PM2 + Apps managed into `/var/log/syslog`
+Redirect all logs of PM2 + Apps managed into `syslog`
 
-## Configure OS
-
-Edit `/etc/rsyslog.conf` and uncomment:
-
-```
-# provides UDP syslog reception
-module(load="imudp")
-input(type="imudp" port="514")
-```
-
-Restart rsyslog:
-
-```
-$ sudo service rsyslog restart
-```
 
 ## Install module
 
 ```
 # Install
-$ pm2 install pm2-syslog
+$ pm2 install pm2-syslog2
 
-# change the default hostname using
-$ pm2 set pm2-syslog:hostname localhost
+# Configure pm2-syslog2 depending to where your syslog daemon listens
+$ pm2 set pm2-syslog:hostname localhost  # localhost is the default.
+$ pm2 set pm2-syslog:port 514  # 514 is the default.
+# or
+$ pm2 set pm2-syslog:path /dev/log
+
+# Optionally change the facility
+$ pm2 set pm2-syslog:facility local0  # user is the default
+
+# Optionally change the log format
+$ pm2 set pm2-syslog:format json  # text is the default
 
 # Uninstall
-$ pm2 uninstall pm2-syslog
+$ pm2 uninstall pm2-syslog2
 ```
 
 # License

--- a/app.js
+++ b/app.js
@@ -9,6 +9,8 @@ var startPM2 = function(conf) {
     var logger = new SysLogger(conf);
     var formatter;
 
+    process.title = 'pm2-syslog2';
+
     logger.setMessageComposer(function(message, severity) {
         if (conf.format == 'json') {
             return new Buffer('<' + (this.facility * 8 + severity) + '>' +

--- a/app.js
+++ b/app.js
@@ -1,31 +1,41 @@
 var startPM2 = function(conf) {
     var pm2       = require('pm2');
     var SysLogger = require('ain2');
-    var sysLoggerSettings = {
-        tag: 'pm2',
-        facility: 'user'
-    };
-    if (conf.hostname) {
-        sysLoggerSettings.hostname = conf.hostname;
+
+    if (conf.port) {
+        conf.port = parseInt(conf.port, 10);
     }
-    var logger = new SysLogger(sysLoggerSettings);
+    var logger = new SysLogger(conf);
+
     pm2.launchBus(function(err, bus) {
         bus.on('*', function(event, data) {
             if (event == 'process:event') {
-                logger.warn('app=pm2 target_app=%s target_id=%s restart_count=%s status=%s',
-                            data.process.name,
-                            data.process.pm_id,
-                            data.process.restart_time,
-                            data.event);
+                if (conf.format == "text") {
+                    logger.warn('app=pm2 target_app=%s target_id=%s restart_count=%s status=%s',
+                                data.process.name,
+                                data.process.pm_id,
+                                data.process.restart_time,
+                                data.event);
+                } else {
+                    logger.warn(JSON.stringify(data));
+                }
             }
         });
 
         bus.on('log:err', function(data) {
-            logger.error('app=%s id=%s line=%s', data.process.name, data.process.pm_id, data.data);
+            if (conf.format == "text") {
+                logger.error('app=%s id=%s line=%s', data.process.name, data.process.pm_id, data.data);
+            } else {
+                logger.error(JSON.stringify(data));
+            }
         });
 
         bus.on('log:out', function(data) {
-            logger.log('app=%s id=%s line=%s', data.process.name, data.process.pm_id, data.data);
+            if (conf.format == "text") {
+                logger.log('app=%s id=%s line=%s', data.process.name, data.process.pm_id, data.data);
+            } else {
+                logger.error(JSON.stringify(data));
+            }
         });
     });
 };

--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ var startPM2 = function(conf) {
     var SysLogger = require('ain2');
     var sysLoggerSettings = {
         tag: 'pm2',
-        facility: 'syslog'
+        facility: 'user'
     };
     if (conf.hostname) {
         sysLoggerSettings.hostname = conf.hostname;

--- a/app.js
+++ b/app.js
@@ -58,7 +58,7 @@ var startPM2 = function(conf) {
             logger.error(formatter({
                 app: data.process.name,
                 id: data.process.pm_id,
-                message: data.data.replace(/\s*$/, '')
+                msgstr: data.data.replace(/\s*$/, '')
             }));
         });
 
@@ -66,7 +66,7 @@ var startPM2 = function(conf) {
             logger.log(formatter({
                 app: data.process.name,
                 id: data.process.pm_id,
-                message: data.data.replace(/\s*$/, '')
+                msgstr: data.data.replace(/\s*$/, '')
             }));
         });
     });

--- a/app.js
+++ b/app.js
@@ -58,7 +58,7 @@ var startPM2 = function(conf) {
             logger.error(formatter({
                 app: data.process.name,
                 id: data.process.pm_id,
-                message: data.data
+                message: data.data.replace(/\s*$/, '')
             }));
         });
 
@@ -66,7 +66,7 @@ var startPM2 = function(conf) {
             logger.log(formatter({
                 app: data.process.name,
                 id: data.process.pm_id,
-                message: data.data
+                message: data.data.replace(/\s*$/, '')
             }));
         });
     });

--- a/app.js
+++ b/app.js
@@ -1,33 +1,33 @@
-var startPM2 = function(conf){
-  var pm2       = require('pm2');
-  var SysLogger = require('ain2');
-  var sysLoggerSettings = {
-    tag: 'pm2',
-    facility: 'syslog'
-  };
-  if(conf.hostname){
-    sysLoggerSettings.hostname = conf.hostname;
-  }
-  var logger = new SysLogger(sysLoggerSettings);
-  pm2.launchBus(function(err, bus) {
-    bus.on('*', function(event, data){
-      if (event == 'process:event') {
-        logger.warn('app=pm2 target_app=%s target_id=%s restart_count=%s status=%s',
-                    data.process.name,
-                    data.process.pm_id,
-                    data.process.restart_time,
-                    data.event);
-      }
-    });
+var startPM2 = function(conf) {
+    var pm2       = require('pm2');
+    var SysLogger = require('ain2');
+    var sysLoggerSettings = {
+        tag: 'pm2',
+        facility: 'syslog'
+    };
+    if (conf.hostname) {
+        sysLoggerSettings.hostname = conf.hostname;
+    }
+    var logger = new SysLogger(sysLoggerSettings);
+    pm2.launchBus(function(err, bus) {
+        bus.on('*', function(event, data) {
+            if (event == 'process:event') {
+                logger.warn('app=pm2 target_app=%s target_id=%s restart_count=%s status=%s',
+                            data.process.name,
+                            data.process.pm_id,
+                            data.process.restart_time,
+                            data.event);
+            }
+        });
 
-    bus.on('log:err', function(data) {
-      logger.error('app=%s id=%s line=%s', data.process.name, data.process.pm_id, data.data);
-    });
+        bus.on('log:err', function(data) {
+            logger.error('app=%s id=%s line=%s', data.process.name, data.process.pm_id, data.data);
+        });
 
-    bus.on('log:out', function(data) {
-      logger.log('app=%s id=%s line=%s', data.process.name, data.process.pm_id, data.data);
+        bus.on('log:out', function(data) {
+            logger.log('app=%s id=%s line=%s', data.process.name, data.process.pm_id, data.data);
+        });
     });
-  });
 };
 
 module.exports = startPM2;

--- a/app.js
+++ b/app.js
@@ -25,7 +25,6 @@ var startPM2 = function(conf) {
             message.date = logger.getDate();
             message.pid = process.pid;
             message.hostname = logger.hostname;
-            message.tag = logger.tag;
             return JSON.stringify(message);
         };
     } else if (conf.format == 'text') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-syslog2",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Redirect PM2/apps logs to syslog",
   "main": "probe.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-syslog2",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Redirect PM2/apps logs to syslog",
   "main": "probe.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-syslog2",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Redirect PM2/apps logs to syslog",
   "main": "probe.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-syslog2",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Redirect PM2/apps logs to syslog",
   "main": "probe.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-syslog2",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "Redirect PM2/apps logs to syslog",
   "main": "probe.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-syslog2",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Redirect PM2/apps logs to syslog",
   "main": "probe.js",
   "scripts": {
@@ -22,10 +22,10 @@
   "config": {
       "tag": "pm2",
       "facility": "user",
-      "hostname": null,
-      "transport": null,
-      "path": null,
-      "port": null,
+      "hostname": "localhost",
+      "transport": "UDP",
+      "path": "/dev/log",
+      "port": 514,
       "format": "text"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm2-syslog2",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Redirect PM2/apps logs to syslog",
   "main": "probe.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "pm2-syslog",
-  "version": "2.1.0",
+  "name": "pm2-syslog2",
+  "version": "2.2.0",
   "description": "Redirect PM2/apps logs to syslog",
   "main": "probe.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "ain2": "^2.0.0",
-    "pm2": "latest",
+    "pm2": "^2.5.0",
     "pmx": "latest"
   },
   "apps": [

--- a/package.json
+++ b/package.json
@@ -18,5 +18,14 @@
     }
   ],
   "author": "Alexandre Strzelewicz",
-  "license": "MIT"
+  "license": "MIT",
+  "config": {
+      "tag": "pm2",
+      "facility": "user",
+      "hostname": null,
+      "transport": null,
+      "path": null,
+      "port": null,
+      "format": "text"
+  }
 }


### PR DESCRIPTION
That's the version we actually use in production, our syslog daemon listens on /dev/log so we had to modify it. Also we're using json format as it's fowarded to ES so we had to modify it.

There's still an issue: we don't know how to make a configuration optional using pm2 module configuration, if we set "null" pm2 crashes (https://github.com/Unitech/pm2/issues/2972), we can't set undefined as cli-table would expect (undefined does not exist in json) so … I don't know (and don't really care as null looks the right answer, let's wait for pm2 or cli-table to fix it?).